### PR TITLE
Feat kafka file config

### DIFF
--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -105,7 +105,7 @@ impl KafkaConnector {
 
         let mut client_config = ClientConfig::new();
 
-        // Se existir arquivo de configuração, carrega primeiro
+        // If configuration file exists, load it first
         if let Some(config_path) = &config.config_file {
             let config_content = std::fs::read_to_string(config_path)?;
             for line in config_content.lines() {
@@ -117,12 +117,12 @@ impl KafkaConnector {
             }
         }
 
-        // Configurações básicas obrigatórias
+        // Required basic configurations
         client_config
             .set("bootstrap.servers", &config.bootstrap_servers)
             .set("client.id", &config.client_id);
 
-        // Configurações específicas baseadas no protocolo de segurança
+        // Specific configurations based on security protocol
         match config.security_protocol {
             KafkaSecurityProtocol::SaslSsl => {
                 if !config.has_credentials() {
@@ -170,7 +170,7 @@ impl KafkaConnector {
         }
         let kafka_record = FutureRecord::to(&self.topic).payload(&payload).key(&key).headers(kafka_headers);
 
-        // publis and handle response
+        // publish and handle response
         tracing::info!(%key, %payload, ?headers, "publishing kafka event");
         match self.producer.send_result(kafka_record) {
             Err((e, _)) => log_and_err!(reason = e, "failed to queue kafka event"),

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -140,7 +140,10 @@ impl KafkaConnector {
                 }
                 client_config
                     .set("ssl.ca.location", config.ssl_ca_location.as_ref().expect("ssl ca location is required"))
-                    .set("ssl.certificate.location", config.ssl_certificate_location.as_ref().expect("ssl certificate location is required"))
+                    .set(
+                        "ssl.certificate.location",
+                        config.ssl_certificate_location.as_ref().expect("ssl certificate location is required"),
+                    )
                     .set("ssl.key.location", config.ssl_key_location.as_ref().expect("ssl key location is required"));
             }
             KafkaSecurityProtocol::None => {}


### PR DESCRIPTION
This pull request introduces a new feature to the `stratus` repository, specifically in the Kafka infrastructure. The update allows Kafka client configurations to be loaded from an external file, which can be specified using a new `config_file` option. The `KafkaConnector::new` method has been refactored to first parse the configuration file, if provided, and then apply or override settings based on the `KafkaConfig` struct fields. These fields are derived from command-line arguments or environment variables. The update also includes logic to handle different security protocols, including None, SASL_SSL, and SSL.